### PR TITLE
chore: fix default options.brotli value in jsdoc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const getChunkSize = (chunk, enc) => (chunk ? Buffer.byteLength(chunk, enc) : 0)
  * @param {object} [options]
  * @param {number} [options.threshold = 1024] Don't compress responses below this size (in bytes)
  * @param {number} [options.level = -1] Gzip/Brotli compression effort (1-11, or -1 for default)
- * @param {boolean} [options.brotli = false] Generate and serve Brotli-compressed responses
+ * @param {boolean} [options.brotli = true] Generate and serve Brotli-compressed responses
  * @param {boolean} [options.gzip = true] Generate and serve Gzip-compressed responses
  * @param {RegExp} [options.mimes] Regular expression of response MIME types to compress (default: text|javascript|json|xml)
  * @returns {(req: Pick<import('http').IncomingMessage, 'method'|'headers'>, res: import('http').ServerResponse, next?:Function) => void}


### PR DESCRIPTION
Fix the default value of `options.brotli` in jsdoc, the default value is `true`.